### PR TITLE
tweaks how explosions work, fixes #15

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -9,6 +9,9 @@
 /proc/iswall(turf/T)
 	return (istype(T, /turf/simulated/wall) || istype(T, /turf/unsimulated/wall) || istype(T, /turf/simulated/shuttle/wall))
 
+/proc/isbarrier(turf/T)
+	. = T.density
+
 /proc/isfloor(turf/T)
 	return (istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
 

--- a/code/modules/cell_auto/cell.dm
+++ b/code/modules/cell_auto/cell.dm
@@ -18,7 +18,7 @@
 	var/group_type = /datum/ca_group
 
 /atom/movable/cell/New(loc as turf, var/set_group = null)
-	..()
+	. = ..()
 
 	var/turf/T = get_turf(src)
 	if(T) // Checking and setting the turf's automata cell
@@ -48,16 +48,10 @@
 	return
 
 /atom/movable/cell/proc/shouldProcess()
-	if(shouldDie())
-		return 0
-
-	return 1
+	. = shouldDie()
 
 /atom/movable/cell/proc/shouldDie()
-	if(age_max && age >= age_max)
-		return 1
-
-	return 0
+	. = age_max && age >= age_max
 
 /atom/movable/cell/proc/spread()
 	return
@@ -73,9 +67,7 @@
 
 	group = null
 
-	..()
-
-	return
+	. = ..()
 
 /atom/movable/cell/singularity_act()
 	return

--- a/code/modules/cell_auto/group.dm
+++ b/code/modules/cell_auto/group.dm
@@ -7,7 +7,7 @@
 	var/list/atom/movable/cell/cells = list()
 
 /datum/ca_group/New(var/loc as turf, size = 0)
-	..()
+	. = ..()
 
 	if(loc && cell_type)
 		new cell_type(loc, src)
@@ -19,7 +19,7 @@
 	for(var/cell in cells)
 		qdel(cell)
 
-	..()
+	. = ..()
 
 /datum/ca_group/proc/process()
 	if(!cells.len)
@@ -31,7 +31,4 @@
 	group_age++
 
 /datum/ca_group/proc/shouldProcess()
-	if(group_age_max && group_age >= group_age_max)
-		return 0
-
-	return 1
+	. = group_age_max && group_age >= group_age_max

--- a/code/modules/cell_auto/groups/explosion.dm
+++ b/code/modules/cell_auto/groups/explosion.dm
@@ -25,12 +25,10 @@
 	var/list/affected_turfs = list()
 
 /datum/ca_group/explosion/shouldProcess()
-	if(group_age <= group_age_max)
-		return 1
-	return 0
+	. = group_age <= group_age_max
 
 /datum/ca_group/explosion/New(var/loc as turf, var/devastation, var/heavy_impact, var/light_impact)
-	..()
+	. = ..()
 
 	start_loc = loc
 
@@ -60,7 +58,7 @@
 	if(!air_processing_deferred)
 		air_processing_killed = 0
 
-	..()
+	. = ..()
 
 /datum/ca_group/explosion/process()
 	// hacky AF, makes explosions process twice per tick so they spread fast
@@ -100,10 +98,10 @@
 
 /datum/ca_group/explosion/proc/getSeverity()
 	if(group_age <= devastation_range)
-		return 1.0
+		. = 1.0
 	else if(group_age <= heavy_impact_range)
-		return 2.0
+		. = 2.0
 	else if(group_age <= light_impact_range)
-		return 3.0
+		. = 3.0
 	else
-		return 0
+		. = 0.0

--- a/code/modules/cell_auto/handler.dm
+++ b/code/modules/cell_auto/handler.dm
@@ -17,10 +17,5 @@
 	for(var/datum/ca_group/group in groups)
 		group.process()
 
-	return
-
 /datum/cell_auto_handler/proc/shouldProcess()
-	if(((world.timeofday - last_tick) > delay) || ((world.timeofday - last_tick) < 0))
-		return 1
-
-	return 0
+	. = (world.timeofday - last_tick) > delay || (world.timeofday - last_tick) < 0

--- a/code/modules/cell_auto/types/explosion.dm
+++ b/code/modules/cell_auto/types/explosion.dm
@@ -21,13 +21,13 @@
 	var/severity = 0
 
 /atom/movable/cell/explosion/New()
-	..()
+	. = ..()
 
 	set_light(0.5, 1, 3, l_color = light_color)
 	update_icon()
 
 /atom/movable/cell/explosion/update_icon()
-	..()
+	. = ..()
 
 	var/datum/ca_group/explosion/G = group
 
@@ -43,7 +43,7 @@
 	var/spawn_wait = rand(1, M.max_cell_age)
 	severity = M.getSeverity()
 
-	if(iswall(src.loc) || prob(act_chance))
+	if(!loc.Enter(src))
 		exAct(spawn_wait)
 	else
 		spawn(spawn_wait)
@@ -61,7 +61,9 @@
 
 /atom/movable/cell/explosion/proc/exAct(var/spawn_wait = 1)
 	for(var/atom/movable/AM in src.loc.contents)
+	{
 		AM.ex_act(severity)
+	}
 
 	src.loc.ex_act(severity)
 
@@ -71,13 +73,16 @@
 
 /atom/movable/cell/explosion/proc/checkTurf(var/turf/T)
 	if(!T)
-		return 0
+		. = 0
+		return
 
 	if(T.containsCell(type))
-		return 0
+		. = 0
+		return
 
 	var/datum/ca_group/explosion/M = group
 	if(M && T in M.affected_turfs)
-		return 0
+		. = 0
+		return
 
-	return 1
+	. = 1


### PR DESCRIPTION
### Description
Cell auto system now uses `.` to return data. Also explosions can properly break through solid objects now, doors and windows should no longer halt an explosion in its tracks.

### Changelog
:cl: Kwask
bugfix: Explosion now properly break through solid objects
/:cl: